### PR TITLE
Adds script for pausing at height with BQ printers

### DIFF
--- a/scripts/BQ_PauseAtHeight.py
+++ b/scripts/BQ_PauseAtHeight.py
@@ -34,7 +34,7 @@ class BQ_PauseAtHeight(Script):
                     if current_z != None:
                         if current_z >= pause_z:
                             prepend_gcode = ";TYPE:CUSTOM\n"
-                            prepend_gcode = "; -- Pause at height (%.2f mm) --\n" % pause_z
+                            prepend_gcode += "; -- Pause at height (%.2f mm) --\n" % pause_z
 
                             # Insert Pause gcode
                             prepend_gcode += "M25        ; Pauses the print and waits for the user to resume it\n"

--- a/scripts/BQ_PauseAtHeight.py
+++ b/scripts/BQ_PauseAtHeight.py
@@ -1,0 +1,47 @@
+from ..Script import Script
+class BQ_PauseAtHeight(Script):
+    def __init__(self):
+        super().__init__()
+        
+    def getSettingData(self):
+        return { 
+            "label":"Pause at height (BQ Printers)",
+            "key": "BQ_PauseAtHeight",
+            "settings": 
+            {
+                "pause_height": 
+                {
+                    "label": "Pause height",
+                    "description": "At what height should the pause occur",
+                    "unit": "mm",
+                    "type": "float",
+                    "default": 5.0,
+                    "visible": True
+                }
+            }
+        }
+    
+    def execute(self, data):
+        x = 0.
+        y = 0.
+        current_z = 0.
+        pause_z = self.getSettingValueByKey("pause_height")
+        for layer in data: 
+            lines = layer.split("\n")
+            for line in lines:
+                if self.getValue(line, 'G') == 1 or self.getValue(line, 'G') == 0:
+                    current_z = self.getValue(line, 'Z')
+                    if current_z != None:
+                        if current_z >= pause_z:
+                            prepend_gcode = ";TYPE:CUSTOM\n"
+                            prepend_gcode = "; -- Pause at height (%.2f mm) --\n" % pause_z
+
+                            # Insert Pause gcode
+                            prepend_gcode += "M25        ; Pauses the print and waits for the user to resume it\n"
+                            
+                            index = data.index(layer) 
+                            layer = prepend_gcode + layer
+                            data[index] = layer # Override the data of this layer with the modified data
+                            return data
+                        break
+        return data


### PR DESCRIPTION
Since BQ printers use a different gcode to pause (M25), this script inserts said gcode before the defined layer height.
