### PR TITLE
Prevent invisible elements from catching the mouse focus

### DIFF
--- a/PostProcessingPlugin.qml
+++ b/PostProcessingPlugin.qml
@@ -321,6 +321,7 @@ UM.Dialog
                         Behavior on height { NumberAnimation { duration: 100 } }
                         opacity: provider.properties.enabled == "True" ? 1 : 0
                         Behavior on opacity { NumberAnimation { duration: 100 } }
+                        enabled: opacity > 0
                         property var definition: model
                         property var settingDefinitionsModel: definitionsModel
                         property var propertyProvider: provider


### PR DESCRIPTION
Hovering over the Tweak at Z check boxes will not always show the arrow cursor but a text entry cursor. The check box cannot be selected this way. This is because there is an 100% transparent control fighting for attention.

CURA-2402
