### PR TITLE
Hide the non-functional revert button on settings

### DIFF
--- a/PostProcessingPlugin.qml
+++ b/PostProcessingPlugin.qml
@@ -332,7 +332,7 @@ UM.Dialog
                         asynchronous: model.type != "enum" && model.type != "extruder"
 
                         onLoaded: {
-                            settingLoader.item.showRevertButton = true
+                            settingLoader.item.showRevertButton = false
                             settingLoader.item.showInheritButton = false
                             settingLoader.item.showLinkedSettingIcon = false
                             settingLoader.item.doDepthIndentation = true


### PR DESCRIPTION
The revert button on settings does not work in the postprocessing window, so this PR just hides it
