### PR TITLE
Fix for tweaking sub-mm Z

### DIFF
--- a/scripts/TweakAtZ.py
+++ b/scripts/TweakAtZ.py
@@ -293,7 +293,7 @@ class TweakAtZ(Script):
             m = re.search("^[+-]?[0-9]*", subPart)
         else:
             #the minus at the beginning allows for negative values, e.g. for delta printers
-            m = re.search("^[-]?[0-9]+\.?[0-9]*", subPart)
+            m = re.search("^[-]?[0-9]*\.?[0-9]*", subPart)
         if m == None:
             return default
         try:


### PR DESCRIPTION
The parsing regexp expects  a digit to start a number, but it is not the case when the value is smaller than one:
```
G0 F2880 X93.769 Y88.073 Z.3
```
Proposed fix: replace "^[-]?[0-9]+\.?[0-9]*" with "^[-]?[0-9]*\.?[0-9]*"