### PR TITLE
Should fix #41 -> layers redone **after** the pause.

### DIFF
--- a/scripts/PauseAtHeight.py
+++ b/scripts/PauseAtHeight.py
@@ -78,7 +78,10 @@ class PauseAtHeight(Script):
             }
         }"""
 
-    def execute(self, data):
+    def execute(self, data: list):
+
+        """data is a list. Each index contains a layer"""
+
         x = 0.
         y = 0.
         current_z = 0.
@@ -91,6 +94,7 @@ class PauseAtHeight(Script):
         park_y = self.getSettingValueByKey("head_park_y")
         layers_started = False
         redo_layers = self.getSettingValueByKey("redo_layers")
+
         for layer in data:
             lines = layer.split("\n")
             for line in lines:
@@ -105,11 +109,11 @@ class PauseAtHeight(Script):
                     current_z = self.getValue(line, 'Z')
                     x = self.getValue(line, 'X', x)
                     y = self.getValue(line, 'Y', y)
-                    if current_z != None:
+                    if current_z is not None:
                         if current_z >= pause_z:
 
                             index = data.index(layer)
-                            prevLayer = data[index-1]
+                            prevLayer = data[index - 1]
                             prevLines = prevLayer.split("\n")
                             current_e = 0.
                             for prevLine in reversed(prevLines):
@@ -117,28 +121,33 @@ class PauseAtHeight(Script):
                                 if current_e >= 0:
                                     break
 
+                            # include a number of previous layers
+                            for i in range(1, redo_layers + 1):
+                                prevLayer = data[index - i]
+                                layer = prevLayer + layer
+
                             prepend_gcode = ";TYPE:CUSTOM\n"
                             prepend_gcode += ";added code by post processing\n"
                             prepend_gcode += ";script: PauseAtHeight.py\n"
                             prepend_gcode += ";current z: %f \n" % (current_z)
 
-                            #Retraction
+                            # Retraction
                             prepend_gcode += "M83\n"
                             if retraction_amount != 0:
                                 prepend_gcode += "G1 E-%f F%f\n" % (retraction_amount, retraction_speed * 60)
 
-                            #Move the head away
+                            # Move the head away
                             prepend_gcode += "G1 Z%f F300\n" % (current_z + 1)
                             prepend_gcode += "G1 X%f Y%f F9000\n" % (park_x, park_y)
                             if current_z < 15:
                                 prepend_gcode += "G1 Z15 F300\n"
 
-                            #Disable the E steppers
+                            # Disable the E steppers
                             prepend_gcode += "M84 E0\n"
-                            #Wait till the user continues printing
+                            # Wait till the user continues printing
                             prepend_gcode += "M0 ;Do the actual pause\n"
 
-                            #Push the filament back,
+                            # Push the filament back,
                             if retraction_amount != 0:
                                 prepend_gcode += "G1 E%f F%f\n" % (retraction_amount, retraction_speed * 60)
 
@@ -146,29 +155,28 @@ class PauseAtHeight(Script):
                             if extrude_amount != 0:
                                 prepend_gcode += "G1 E%f F%f\n" % (extrude_amount, extrude_speed * 60)
 
-                            # and retract again, the properly primes the nozzle when changing filament.
+                            # and retract again, the properly primes the nozzle
+                            # when changing filament.
                             if retraction_amount != 0:
                                 prepend_gcode += "G1 E-%f F%f\n" % (retraction_amount, retraction_speed * 60)
 
-                            #Move the head back
+                            # Move the head back
                             prepend_gcode += "G1 Z%f F300\n" % (current_z + 1)
-                            prepend_gcode +="G1 X%f Y%f F9000\n" % (x, y)
+                            prepend_gcode += "G1 X%f Y%f F9000\n" % (x, y)
                             if retraction_amount != 0:
-                                prepend_gcode +="G1 E%f F%f\n" % (retraction_amount, retraction_speed * 60)
-                            prepend_gcode +="G1 F9000\n"
-                            prepend_gcode +="M82\n"
+                                prepend_gcode += "G1 E%f F%f\n" % (retraction_amount, retraction_speed * 60)
+                            prepend_gcode += "G1 F9000\n"
+                            prepend_gcode += "M82\n"
 
                             # reset extrude value to pre pause value
-                            prepend_gcode +="G92 E%f\n" % (current_e)
+                            prepend_gcode += "G92 E%f\n" % (current_e)
 
                             layer = prepend_gcode + layer
 
-                            # include a number of previous layers
-                            for i in range(1, redo_layers + 1):
-                                prevLayer = data[index-i]
-                                layer = prevLayer + layer
 
-                            data[index] = layer #Override the data of this layer with the modified data
+                            # Override the data of this layer with the
+                            # modified data
+                            data[index] = layer
                             return data
                         break
         return data


### PR DESCRIPTION
Also, I made the code of the execute function a bit more PEP8.

A block of code was simply misplaced.

Here is the new gcode generated by the plugin (you can compare it to the gcode I attached in the issue):

[UM2_POC_extraction_cartridge.txt](https://github.com/nallath/PostProcessingPlugin/files/916523/UM2_POC_extraction_cartridge.txt)

Layers 81 and 82 are now redone **after** the pause.