### PR TITLE
Add standby and resume temperature for pauseAtHeight.

### DIFF
--- a/scripts/PauseAtHeight.py
+++ b/scripts/PauseAtHeight.py
@@ -74,6 +74,22 @@ class PauseAtHeight(Script):
                     "unit": "layers",
                     "type": "int",
                     "default_value": 0
+                },
+                "standby_temperature":
+                {
+                    "label": "Standby Temperature",
+                    "description": "Change the temperature during the pause",
+                    "unit": "degrees",
+                    "type": "int",
+                    "default_value": 0
+                },
+                "resume_temperature":
+                {
+                    "label": "Resume Temperature",
+                    "description": "Change the temperature after the pause",
+                    "unit": "degrees",
+                    "type": "int",
+                    "default_value": 0
                 }
             }
         }"""
@@ -94,6 +110,8 @@ class PauseAtHeight(Script):
         park_y = self.getSettingValueByKey("head_park_y")
         layers_started = False
         redo_layers = self.getSettingValueByKey("redo_layers")
+        standby_temperature = self.getSettingValueByKey("standby_temperature")
+        resume_temperature = self.getSettingValueByKey("resume_temperature")
 
         for layer in data:
             lines = layer.split("\n")
@@ -144,8 +162,15 @@ class PauseAtHeight(Script):
 
                             # Disable the E steppers
                             prepend_gcode += "M84 E0\n"
+
+                            # Set extruder standby temperature
+                            prepend_gcode += "M104 S%i; standby temperature\n" % (standby_temperature)
+
                             # Wait till the user continues printing
                             prepend_gcode += "M0 ;Do the actual pause\n"
+
+                            # Set extruder resume temperature
+                            prepend_gcode += "M109 S%i; resume temperature\n" % (resume_temperature)
 
                             # Push the filament back,
                             if retraction_amount != 0:

--- a/scripts/PauseAtHeight.py
+++ b/scripts/PauseAtHeight.py
@@ -1,4 +1,6 @@
 from ..Script import Script
+# from cura.Settings.ExtruderManager import ExtruderManager
+
 class PauseAtHeight(Script):
     def __init__(self):
         super().__init__()
@@ -79,7 +81,7 @@ class PauseAtHeight(Script):
                 {
                     "label": "Standby Temperature",
                     "description": "Change the temperature during the pause",
-                    "unit": "degrees",
+                    "unit": "°C",
                     "type": "int",
                     "default_value": 0
                 },
@@ -87,7 +89,7 @@ class PauseAtHeight(Script):
                 {
                     "label": "Resume Temperature",
                     "description": "Change the temperature after the pause",
-                    "unit": "degrees",
+                    "unit": "°C",
                     "type": "int",
                     "default_value": 0
                 }
@@ -112,6 +114,10 @@ class PauseAtHeight(Script):
         redo_layers = self.getSettingValueByKey("redo_layers")
         standby_temperature = self.getSettingValueByKey("standby_temperature")
         resume_temperature = self.getSettingValueByKey("resume_temperature")
+
+        # T = ExtruderManager.getInstance().getActiveExtruderStack().getProperty("material_print_temperature", "value")
+        # with open("out.txt", "w") as f:
+            # f.write(T)
 
         for layer in data:
             lines = layer.split("\n")


### PR DESCRIPTION
Avoids burning filament during long pauses.

Hi !

I implemented this feature because I needed it. I have several 3D printers at work, and some of my prints have embedded pauses. Sometimes, the prints pause during the night, and the extruder is not shut off. It results in burnt filament, and nozzle clogging.

With this feature, I can set a standby temperature during the pause (I set it to 0°C, turning off the extruder), and when I choose to resume, the extruder will first reach the "resume temperature" before resuming printing.

This feature is available on 3D printers like 3D touch by default, and I think it's missing in Cura.

I tested it and it works.