### PR TITLE
Local container providers

### DIFF
--- a/Script.py
+++ b/Script.py
@@ -43,7 +43,7 @@ class Script:
                 ContainerRegistry.getInstance().addContainer(self._definition)
         self._stack.addContainer(self._definition)
         self._instance = InstanceContainer(container_id="ScriptInstanceContainer")
-        self._instance.setDefinition(self._definition)
+        self._instance.setDefinition(self._definition.getId())
         self._instance.addMetaDataEntry("setting_version", self._definition.getMetaDataEntry("setting_version", default = 0))
         self._stack.addContainer(self._instance)
         self._stack.propertyChanged.connect(self._onPropertyChanged)


### PR DESCRIPTION
This is part of the container provider rework. The setDefinition function now accepts a definition ID instead of the full definition.

Contributes to issue CURA-4243.